### PR TITLE
Read SOAPAction from soap envelope's headers

### DIFF
--- a/src/SoapCore/HeadersHelper.cs
+++ b/src/SoapCore/HeadersHelper.cs
@@ -98,6 +98,24 @@ namespace SoapCore
 					}
 				}
 
+				if (string.IsNullOrEmpty(soapAction))
+				{
+					if (!string.IsNullOrEmpty(message.Headers.Action))
+					{
+						soapAction = message.Headers.Action;
+					}
+
+					if (string.IsNullOrEmpty(soapAction))
+					{
+						var headerInfo = message.Headers.FirstOrDefault(h => h.Name.ToLowerInvariant() == "action");
+
+						if (headerInfo != null)
+						{
+							soapAction = message.Headers.GetHeader<string>(headerInfo.Name, headerInfo.Namespace);
+						}
+					}
+				}
+
 				if (string.IsNullOrEmpty(soapAction) && reader != null)
 				{
 					soapAction = reader.LocalName;


### PR DESCRIPTION
Actually, it is not possible to retrieve the SOAPAction from the soap request's header. This code tries to check if the soap envelope contains any reference about what is the SOAPAction inside the header Action tag. If so, then it read the SOAPAction from the found tag.